### PR TITLE
New package releases

### DIFF
--- a/esp-hal-buzzer/CHANGELOG.md
+++ b/esp-hal-buzzer/CHANGELOG.md
@@ -15,4 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## 0.1.0 - 2024-08-21 - Initial release
+## 0.1.0 - 2024-10-14
+
+### Added
+
+- Initial release

--- a/esp-hal-buzzer/Cargo.toml
+++ b/esp-hal-buzzer/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "esp-hal-buzzer"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.76.0"
+name         = "esp-hal-buzzer"
+version      = "0.1.0"
+edition      = "2021"
+rust-version = "1.79.0"
 description  = "Buzzer driver for esp-hal"
 repository   = "https://github.com/esp-rs/esp-hal-community"
 license      = "MIT OR Apache-2.0"
@@ -14,16 +14,16 @@ targets  = ["riscv32imc-unknown-none-elf"]
 [dependencies]
 defmt             = { version = "0.3.8", optional = true }
 document-features = "0.2.10"
-esp-hal           = "0.20.1"
+esp-hal           = "0.21.0"
 fugit             = "0.3.7"
 
 [dev-dependencies]
-esp-backtrace = { version = "0.14.1", features = [
+esp-backtrace = { version = "0.14.2", features = [
   "exception-handler",
   "panic-handler",
   "println",
 ] }
-esp-println = "0.11.0"
+esp-println = "0.12.0"
 
 [features]
 ## Implement `defmt::Format` on certain types.

--- a/esp-hal-buzzer/Cargo.toml
+++ b/esp-hal-buzzer/Cargo.toml
@@ -44,7 +44,3 @@ esp32h2 = ["esp-backtrace/esp32h2", "esp-hal/esp32h2", "esp-println/esp32h2"]
 esp32s2 = ["esp-backtrace/esp32s2", "esp-hal/esp32s2", "esp-println/esp32s2"]
 ## Target the ESP32-S3.
 esp32s3 = ["esp-backtrace/esp32s3", "esp-hal/esp32s3", "esp-println/esp32s3"]
-
-# Patch until next esp-hal release
-[patch.crates-io]
-esp-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "a787a13" }

--- a/esp-hal-buzzer/README.md
+++ b/esp-hal-buzzer/README.md
@@ -14,6 +14,36 @@ A few songs are included in the [songs](./src/songs.rs) module. Contributions ar
 
 [documentation]: https://docs.rs/esp-hal-buzzer/
 
+## Examples
+
+We have provided Cargo aliases to simplify the process of building and flashing the examples.
+
+Please first make sure that you have installed [espflash]:
+
+```
+cargo install espflash --locked
+```
+
+Additionally, if you are targeting an Xtensa chip (ESP32, ESP32-S2, or ESP32-S3) you must install the `esp` toolchain using [espup]:
+
+```
+cargo install espup
+espup install
+```
+
+Then, to run e.g. the `buzzer.rs` example, you can run:
+
+```
+cargo esp32c6 --example=buzzer
+# Xtensa chips require the `esp` toolchain:
+cargo +esp esp32s3 --example=buzzer
+```
+
+You can modify the above command to reflect the chip you wish to target. See `.cargo/config.toml` for more information on how these aliases work.
+
+[espflash]: https://github.com/esp-rs/espflash
+[espup]: https://github.com/esp-rs/espup
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_

--- a/esp-hal-smartled/.cargo/config.toml
+++ b/esp-hal-smartled/.cargo/config.toml
@@ -1,10 +1,21 @@
+[alias]
+esp32   = "run --release --features=esp32   --target=xtensa-esp32-none-elf"
+esp32c2 = "run --release --features=esp32c2 --target=riscv32imc-unknown-none-elf"
+esp32c3 = "run --release --features=esp32c3 --target=riscv32imc-unknown-none-elf"
+esp32c6 = "run --release --features=esp32c6 --target=riscv32imac-unknown-none-elf"
+esp32h2 = "run --release --features=esp32h2 --target=riscv32imac-unknown-none-elf"
+esp32s2 = "run --release --features=esp32s2 --target=xtensa-esp32s2-none-elf"
+esp32s3 = "run --release --features=esp32s3 --target=xtensa-esp32s3-none-elf"
+
 [target.'cfg(target_arch = "riscv32")']
+runner    = "espflash flash --monitor"
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
   "-C", "force-frame-pointers",
 ]
 
 [target.'cfg(target_arch = "xtensa")']
+runner    = "espflash flash --monitor"
 rustflags = [
   # GNU LD
   "-C", "link-arg=-Wl,-Tlinkall.x",
@@ -14,3 +25,6 @@ rustflags = [
   # "-C", "link-arg=-Tlinkall.x",
   # "-C", "linker=rust-lld",
 ]
+
+[unstable]
+build-std = ["core"]

--- a/esp-hal-smartled/CHANGELOG.md
+++ b/esp-hal-smartled/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## 0.14.0 - 2024-10-14
+
+### Changed
+
+- Use latest release of `esp-hal` (#8)
+
+### Removed
+
 - Removed the `clocks` parameter from `SmartLedsAdapter::new` (#1999)
 
 ## 0.13.0 - 2024-08-29

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name         = "esp-hal-smartled"
-version      = "0.13.0"
+version      = "0.14.0"
 edition      = "2021"
-rust-version = "1.76.0"
+rust-version = "1.79.0"
 description  = "RMT peripheral adapter for smart LEDs"
 repository   = "https://github.com/esp-rs/esp-hal-community"
 license      = "MIT OR Apache-2.0"
@@ -14,18 +14,18 @@ targets  = ["riscv32imac-unknown-none-elf"]
 [dependencies]
 defmt             = { version = "0.3.8", optional = true }
 document-features = "0.2.10"
-esp-hal           = "0.20.0"
+esp-hal           = "0.21.0"
 fugit             = "0.3.7"
 smart-leds-trait  = "0.3.0"
 
 [dev-dependencies]
 cfg-if = "1.0.0"
-esp-backtrace = { version = "0.14.1", features = [
+esp-backtrace = { version = "0.14.2", features = [
     "exception-handler",
     "panic-handler",
     "println",
 ] }
-esp-println = "0.11.0"
+esp-println = "0.12.0"
 smart-leds = "0.4.0"
 
 [features]

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -45,9 +45,3 @@ esp32h2 = ["esp-backtrace/esp32h2", "esp-hal/esp32h2", "esp-println/esp32h2"]
 esp32s2 = ["esp-backtrace/esp32s2", "esp-hal/esp32s2", "esp-println/esp32s2"]
 ## Target the ESP32-S3.
 esp32s3 = ["esp-backtrace/esp32s3", "esp-hal/esp32s3", "esp-println/esp32s3"]
-
-# TODO: Remove patches prior to next release
-[patch.crates-io]
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal", rev = "d44affc" }
-esp-hal       = { git = "https://github.com/esp-rs/esp-hal", rev = "d44affc" }
-esp-println   = { git = "https://github.com/esp-rs/esp-hal", rev = "d44affc" }

--- a/esp-hal-smartled/README.md
+++ b/esp-hal-smartled/README.md
@@ -14,6 +14,36 @@ Allows for the use of an RMT output channel to easily interact with RGB LEDs and
 
 [documentation]: https://docs.rs/esp-hal-smartled/
 
+## Examples
+
+We have provided Cargo aliases to simplify the process of building and flashing the examples.
+
+Please first make sure that you have installed [espflash]:
+
+```
+cargo install espflash --locked
+```
+
+Additionally, if you are targeting an Xtensa chip (ESP32, ESP32-S2, or ESP32-S3) you must install the `esp` toolchain using [espup]:
+
+```
+cargo install espup
+espup install
+```
+
+Then, to run e.g. the `hello_rgb.rs` example, you can run:
+
+```
+cargo esp32c6 --example=hello_rgb
+# Xtensa chips require the `esp` toolchain:
+cargo +esp esp32s3 --example=hello_rgb
+```
+
+You can modify the above command to reflect the chip you wish to target. See `.cargo/config.toml` for more information on how these aliases work.
+
+[espflash]: https://github.com/esp-rs/espflash
+[espup]: https://github.com/esp-rs/espup
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_


### PR DESCRIPTION
- Update both packages to use latest versions of `esp-hal` and other dev dependencies
- Update MSRVs to match that of `esp-hal`
- Add instructions to the `README.md` files demonstrating how to build and run the examples
- Make `.cargo/config.toml` files consistent between packages

Looks like we forgot to publish the initial version of `esp-hal-buzzer` when it was added, oops. Once this PR is merged I will publish both packages.

Closes #7