### PR TITLE
Updated timings for ws28xx/sk68xx & clones.

### DIFF
--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -34,10 +34,10 @@ use esp_hal::{
 };
 use smart_leds_trait::{SmartLedsWrite, RGB8};
 
-const SK68XX_CODE_PERIOD: u32 = 1200;
-const SK68XX_T0H_NS: u32 = 320;
+const SK68XX_CODE_PERIOD: u32 = 1250; // 800kHz
+const SK68XX_T0H_NS: u32 = 400; // 300ns per SK6812 datasheet, 400 per WS2812. Some require >350ns for T0H. Others <500ns for T0H.
 const SK68XX_T0L_NS: u32 = SK68XX_CODE_PERIOD - SK68XX_T0H_NS;
-const SK68XX_T1H_NS: u32 = 640;
+const SK68XX_T1H_NS: u32 = 850; // 900ns per SK6812 datasheet, 850 per WS2812. > 550ns is sometimes enough. Some require T1H >= 2 * T0H. Some require > 300ns T1L.
 const SK68XX_T1L_NS: u32 = SK68XX_CODE_PERIOD - SK68XX_T1H_NS;
 
 /// All types of errors that can happen during the conversion and transmission


### PR DESCRIPTION
The existing timings don't work reliably with all my various ws28xx clones. This set of timings is more reliable.

I added some notes about constraints I discovered. It seems WLED uses 400ns/800ns, which is below datasheet values, but can be a little glitchy on one chipset I tried.

I've used 6 different types of LEDs - these work for all of them.

https://photos.app.goo.gl/nF5x5BMQ2qTPjZ6x8 - some of my tests. The lower genuine (I think) ws2812 works in all cases - original timing and mine. Another 8x8 panel of unknown LEDs only works when T1H >= 850ns and T0H >=350ns. LED tubes from ClenLED using UCS2903 chips need at least 800ns T1H and 400ns T0H

