### PR TITLE
New release for `esp-hal-smartled`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-/esp-hal-smartled/ @jessebraham
 /esp-hal-buzzer/ @AnthonyGrondin

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-hal-smartled"
-version      = "0.13.0"
+version      = "0.14.0"
 edition      = "2021"
 rust-version = "1.76.0"
 description  = "RMT peripheral adapter for smart LEDs"
@@ -12,7 +12,7 @@ features = ["esp32c6"]
 targets  = ["riscv32imac-unknown-none-elf"]
 
 [dependencies]
-defmt             = { version = "0.3.8", optional = true }
+defmt             = { version = "0.3.10", optional = true }
 document-features = "0.2.10"
 esp-hal           = "0.22.0"
 fugit             = "0.3.7"
@@ -20,7 +20,7 @@ smart-leds-trait  = "0.3.0"
 
 [dev-dependencies]
 cfg-if = "1.0.0"
-esp-backtrace = { version = "0.14.1", features = [
+esp-backtrace = { version = "0.14.2", features = [
     "exception-handler",
     "panic-handler",
     "println",

--- a/esp-hal-smartled/README.md
+++ b/esp-hal-smartled/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-hal-smartled?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal-smartled)
 [![docs.rs](https://img.shields.io/docsrs/esp-hal-smartled?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/esp-hal-smartled)
-![MSRV](https://img.shields.io/badge/MSRV-1.76-blue?labelColor=1C2C2E&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.79-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal-smartled?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
@@ -16,7 +16,7 @@ Allows for the use of an RMT output channel to easily interact with RGB LEDs and
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.76 and up. It _might_
+This crate is guaranteed to compile on stable Rust 1.79 and up. It _might_
 compile with older versions but that may change in any new patch release.
 
 ## License


### PR DESCRIPTION
FYI, I will *not* continue to maintain this package after this release, and as such have removed myself from `CODEOWNERS`.

Please see #10, if nobody from the community is willing to step up it's not fair to me that I am forced to continue maintaining a package I have no interest in or use for.

Closes #12