### PR TITLE
feat(esp-hal-smartled): Update to esp-hal 1.0.0-beta.0

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 /esp-hal-buzzer/ @AnthonyGrondin
+/esp-hal-smartled/ @taorye

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -14,7 +14,7 @@ targets  = ["riscv32imac-unknown-none-elf"]
 [dependencies]
 defmt             = { version = "0.3.10", optional = true }
 document-features = "0.2.10"
-esp-hal           = "0.23.1"
+esp-hal           = { version = "1.0.0-beta.0", features = ["unstable"] }
 fugit             = "0.3.7"
 smart-leds-trait  = "0.3.0"
 

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -15,7 +15,6 @@ targets  = ["riscv32imac-unknown-none-elf"]
 defmt             = { version = "0.3.10", optional = true }
 document-features = "0.2.10"
 esp-hal           = { version = "1.0.0-beta.0", features = ["unstable"] }
-fugit             = "0.3.7"
 smart-leds-trait  = "0.3.0"
 
 [dev-dependencies]

--- a/esp-hal-smartled/examples/hello_rgb.rs
+++ b/esp-hal-smartled/examples/hello_rgb.rs
@@ -23,7 +23,7 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{delay::Delay, main, rmt::Rmt, time::RateExtU32};
+use esp_hal::{delay::Delay, main, rmt::Rmt, time::Rate};
 use esp_hal_smartled::{smartLedBuffer, SmartLedsAdapter};
 use smart_leds::{
     brightness, gamma,
@@ -54,9 +54,9 @@ fn main() -> ! {
     // Configure RMT peripheral globally
     cfg_if::cfg_if! {
         if #[cfg(feature = "esp32h2")] {
-            let freq = 32.MHz();
+            let freq = Rate::from_mhz(32);
         } else {
-            let freq = 80.MHz();
+            let freq = Rate::from_mhz(80);
         }
     }
 

--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -11,10 +11,10 @@
 //! ## Example
 //!
 //! ```rust,ignore
-//! let rmt = Rmt::new(peripherals.RMT, 80.MHz(), None).unwrap();
+//! let rmt = Rmt::new(peripherals.RMT, Rate::from_mhz(80)).unwrap();
 //!
 //! let rmt_buffer = smartLedBuffer!(1);
-//! let mut led = SmartLedsAdapter::new(rmt.channel0, peripherals.GPIO2, rmt_buffer);
+//! let mut led = SmartLedsAdapter::new(rmt.channel0, peripherals.GPIO8, rmt_buffer);
 //! ```
 //!
 //! ## Feature Flags

--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -27,7 +27,7 @@ use core::{fmt::Debug, slice::IterMut};
 
 use esp_hal::{
     clock::Clocks,
-    gpio::{OutputPin, Level},
+    gpio::{Level, OutputPin},
     peripheral::Peripheral,
     rmt::{Error as RmtError, PulseCode, TxChannel, TxChannelConfig, TxChannelCreator},
 };
@@ -115,13 +115,13 @@ where
             channel: Some(channel),
             rmt_buffer,
             pulses: (
-                PulseCode::new (
+                PulseCode::new(
                     Level::High,
                     ((SK68XX_T0H_NS * src_clock) / 1000) as u16,
                     Level::Low,
                     ((SK68XX_T0L_NS * src_clock) / 1000) as u16,
                 ),
-                PulseCode::new (
+                PulseCode::new(
                     Level::High,
                     ((SK68XX_T1H_NS * src_clock) / 1000) as u16,
                     Level::Low,


### PR DESCRIPTION
- Bumps `esp-hal` from 0.23.1 to 1.0.0-beta.0
- Refactor to remove `Fugit` dependency to use `Rate` from `esp-hal`