### PR TITLE
fix(esp-hal-buzzer): Don't return an error when muting before the timer has been configured

### DIFF
--- a/esp-hal-buzzer/CHANGELOG.md
+++ b/esp-hal-buzzer/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Breaking Change:** `Buzzer::mute()` is now infallible (#38)
 
 ### Fixed
 - Upgrade esp-hal to 1.0.0-beta.1 (#31)


### PR DESCRIPTION
- Buzzer::mute() is now infallible
- Fixes https://github.com/esp-rs/esp-hal-community/issues/33