### PR TITLE
refactor(esp-hal-buzzer): Enable playing tones from slices instead of fixed-size arrays

### DIFF
--- a/esp-hal-buzzer/CHANGELOG.md
+++ b/esp-hal-buzzer/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- **Breaking Change:** `Buzzer::mute()` is now infallible (#38)
 
 ### Fixed
 - Upgrade esp-hal to 1.0.0-beta.1 (#31)

--- a/esp-hal-buzzer/examples/buzzer.rs
+++ b/esp-hal-buzzer/examples/buzzer.rs
@@ -28,20 +28,20 @@ fn main() -> ! {
         peripherals.GPIO6,
     );
 
-    buzzer.play_song(DOOM).unwrap();
-    buzzer.play_song(FURELISE).unwrap();
-    buzzer.play_song(MERRY_CHRISTMAS).unwrap();
-    buzzer.play_song(MII_CHANNEL).unwrap();
-    buzzer.play_song(NEVER_GONNA_GIVE_YOU_UP).unwrap();
-    buzzer.play_song(ODE_TO_JOY).unwrap();
-    buzzer.play_song(PACMAN).unwrap();
-    buzzer.play_song(STAR_WARS).unwrap();
-    buzzer.play_song(SUPER_MARIO_BROS).unwrap();
-    buzzer.play_song(TAKE_ON_ME).unwrap();
-    buzzer.play_song(TETRIS).unwrap();
-    buzzer.play_song(THE_LION_SLEEPS_TONIGHT).unwrap();
-    buzzer.play_song(ZELDA_LULLABY).unwrap();
-    buzzer.play_song(ZELDA_THEME).unwrap();
+    buzzer.play_song(&DOOM).unwrap();
+    buzzer.play_song(&FURELISE).unwrap();
+    buzzer.play_song(&MERRY_CHRISTMAS).unwrap();
+    buzzer.play_song(&MII_CHANNEL).unwrap();
+    buzzer.play_song(&NEVER_GONNA_GIVE_YOU_UP).unwrap();
+    buzzer.play_song(&ODE_TO_JOY).unwrap();
+    buzzer.play_song(&PACMAN).unwrap();
+    buzzer.play_song(&STAR_WARS).unwrap();
+    buzzer.play_song(&SUPER_MARIO_BROS).unwrap();
+    buzzer.play_song(&TAKE_ON_ME).unwrap();
+    buzzer.play_song(&TETRIS).unwrap();
+    buzzer.play_song(&THE_LION_SLEEPS_TONIGHT).unwrap();
+    buzzer.play_song(&ZELDA_LULLABY).unwrap();
+    buzzer.play_song(&ZELDA_THEME).unwrap();
 
     println!("Done");
 

--- a/esp-hal-buzzer/src/lib.rs
+++ b/esp-hal-buzzer/src/lib.rs
@@ -8,17 +8,16 @@
 //! ## Example
 //!
 //! ```rust,ignore
-//! let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+//! let peripherals = esp_hal::init(esp_hal::Config::default());
 //!
-//! let mut ledc = Ledc::new(peripherals.LEDC, &clocks);
+//! let mut ledc = Ledc::new(peripherals.LEDC);
 //! ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
 //!
 //! let mut buzzer = Buzzer::new(
 //!     &ledc,
 //!     timer::Number::Timer0,
 //!     channel::Number::Channel1,
-//!     io.pins.gpio6,
-//!     &clocks,
+//!     peripherals.GPIO6,
 //! );
 //!
 //! // Play a 1000Hz frequency
@@ -223,24 +222,35 @@ impl<'a> Buzzer<'a> {
     /// Mute the buzzer
     ///
     /// The muting is done by simply setting the duty to 0
-    pub fn mute(&mut self) -> Result<(), Error> {
+    pub fn mute(&self) {
+        // Timer is not configured, we do an early return since no sound is playing anyway.
+        if !self.timer.is_configured() {
+            return;
+        }
         let mut channel = Channel::new(self.channel_number, unsafe {
             self.output_pin.clone_unchecked()
         });
+        // Safety:
+        // - Error::Duty cannot happen, we hardcode 0 which is valid
+        // - Error::Channel cannot happen, channel is configured below
+        // - Error::Timer cannot happen, it's an early return no-op above
         channel
             .configure(channel::config::Config {
                 timer: &self.timer,
                 duty_pct: 0,
                 pin_config: channel::config::PinConfig::PushPull,
             })
-            .map_err(|e| e.into())
+            .unwrap()
     }
 
     /// Play a frequency through the buzzer
     pub fn play(&mut self, frequency: u32) -> Result<(), Error> {
         // Mute if frequency is 0Hz
         if frequency == 0 {
-            return self.mute();
+            return {
+                self.mute();
+                Ok(())
+            };
         }
 
         // Max duty resolution for a frequency:
@@ -310,10 +320,11 @@ impl<'a> Buzzer<'a> {
         for (frequency, timing) in sequence.iter().zip(timings.iter()) {
             self.play(*frequency)?;
             self.delay.delay_millis(*timing);
-            self.mute()?;
+            self.mute();
         }
         // Mute at the end of the sequence
-        self.mute()
+        self.mute();
+        Ok(())
     }
 
     /// Play a tone sequence through the buzzer

--- a/esp-hal-buzzer/src/lib.rs
+++ b/esp-hal-buzzer/src/lib.rs
@@ -61,6 +61,9 @@ pub enum Error {
 
     /// When the volume level is out of range. Either too low or too high.
     VolumeOutOfRange,
+
+    /// Sequence and timings slice aren't of the same length
+    LengthMismatch,
 }
 
 /// Converts [channel::Error] into [self::Error]
@@ -327,6 +330,55 @@ impl<'a> Buzzer<'a> {
         Ok(())
     }
 
+    /// Play a sound sequence through the buzzer
+    ///
+    /// Uses a pair of frequency and duration slices to play a sound sequence.
+    /// Both slices must be of the same length, where each pair of `(frequency, duration)` defines one tone.
+    ///
+    /// # Arguments
+    /// * `sequence` - A slice of frequencies to play through the buzzer
+    /// * `timings` - A slice of durations in milliseconds for each frequency
+    ///
+    /// # Examples
+    /// Play a single beep at 300Hz for 1 second
+    /// ```
+    /// buzzer.play_tones_from_slice(&[300], &[1000]);
+    /// ```
+    ///
+    /// Play a sequence of 3 beeps with a break in between
+    /// ```
+    /// buzzer.play_tones_from_slice(&[200, 0, 200, 0, 200], &[200, 50, 200, 50, 200]);
+    /// ```
+    ///
+    /// Play a sequence of 3 beeps with the same duration
+    /// ```
+    /// buzzer.play_tones_from_slice(&[100, 200, 300], &[100; 3]);
+    /// ```
+    ///
+    /// # Errors
+    /// This function returns an [Error] in the following cases:
+    /// - If the `sequence` and `timings` slices have different lengths ([Error::LengthMismatch])
+    /// - If playing a frequency results in an error
+    pub fn play_tones_from_slice(
+        &mut self,
+        sequence: &[u32],
+        timings: &[u32],
+    ) -> Result<(), Error> {
+        if sequence.len() != timings.len() {
+            return Err(Error::LengthMismatch);
+        }
+
+        // Iterate for each frequency / timing pair
+        for (frequency, timing) in sequence.iter().zip(timings.iter()) {
+            self.play(*frequency)?;
+            self.delay.delay_millis(*timing);
+            self.mute();
+        }
+        // Mute at the end of the sequence
+        self.mute();
+        Ok(())
+    }
+
     /// Play a tone sequence through the buzzer
     ///
     /// Uses a pair of frequencies and timings to play a sound sequence.
@@ -351,19 +403,20 @@ impl<'a> Buzzer<'a> {
     ///         duration: 100,
     ///     },
     /// ];
-    /// buzzer.play_song(song);
+    /// buzzer.play_song(&song);
     /// ```
     ///
     /// # Errors
     /// This function returns an [Error] in case of an error.
     /// An error can occur when an invalid value is used as a tone
-    pub fn play_song<const T: usize>(&mut self, tones: [ToneValue; T]) -> Result<(), Error> {
-        let mut sequence: [u32; T] = [0; T];
-        let mut timings: [u32; T] = [0; T];
-        for (index, tone) in tones.iter().enumerate() {
-            sequence[index] = tone.frequency;
-            timings[index] = tone.duration;
+    pub fn play_song(&mut self, tones: &[ToneValue]) -> Result<(), Error> {
+        for tone in tones {
+            self.play(tone.frequency)?;
+            self.delay.delay_millis(tone.duration);
+            self.mute();
         }
-        self.play_tones(sequence, timings)
+        // Mute at the end of the sequence
+        self.mute();
+        Ok(())
     }
 }


### PR DESCRIPTION
- Built on top of #38 
- Add new `Buzzer::play_tones_from_slice(&mut self, sequence: &[u32],
timings: &[u32])` to play tones from slices.
- :warning: BREAKING CHANGE: `Buzzer::play_song()` now takes a slice instead of a fixed-size array.