### PR TITLE
improve tooling by introducing justfile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,3 @@
-[alias]
-esp32   = "run --release --features=esp32,esp-hal/unstable   --target=xtensa-esp32-none-elf"
-esp32c2 = "run --release --features=esp32c2,esp-hal/unstable --target=riscv32imc-unknown-none-elf"
-esp32c3 = "run --release --features=esp32c3,esp-hal/unstable --target=riscv32imc-unknown-none-elf"
-esp32c6 = "run --release --features=esp32c6,esp-hal/unstable --target=riscv32imac-unknown-none-elf"
-esp32h2 = "run --release --features=esp32h2,esp-hal/unstable --target=riscv32imac-unknown-none-elf"
-esp32s2 = "run --release --features=esp32s2,esp-hal/unstable --target=xtensa-esp32s2-none-elf"
-esp32s3 = "run --release --features=esp32s3,esp-hal/unstable --target=xtensa-esp32s3-none-elf"
-
 [build]
 target = "riscv32imac-unknown-none-elf"
 # target = "riscv32imc-unknown-none-elf"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Ignore to allow users changing the toolchain.
+/rust-toolchain.toml

--- a/README.md
+++ b/README.md
@@ -10,14 +10,20 @@ A collection of crates for use alongside [esp-hal], but which are maintained by 
 
 ## Examples
 
-To run the examples for either crate, either open the project at the sub-crate level or change directory:
-
+The following command can be used to run the smart LED example on a ESP32C6 target.
 ```bash
-# cd into crate directory for smartled or buzzer
-cd esp-hal-smartled
-# cargo <chip alias> --example <example name>
-cargo esp32c3 --example hello_rgb # or other chip
+cargo +stable run --example hello_rgb --features "esp32c6,esp-hal/unstable" --target=riscv32imac-unknown-none-elf --release
 ```
+
+This repository also provides a [`justfile`](https://github.com/casey/just) which provides
+`just run-esp32c6 hello_rgb` as a shorthand for the command above. There are also shorthands for
+running other examples and running on other chips. You can use `just --list` to list all provided
+shorthands.
+
+There are two sample toolchain files available for simplifying development:
+`rust-toolchain-risc-v.toml` and `rust-toolchain-xtensa.toml`. Depending on which target you develop
+for, you can use `cp rust-toolchain-risc-v.toml rust-toolchain.toml` or
+`cp rust-toolchain-xtensa.toml rust-toolchain.toml` to set the correct Rust toolchain.
 
 ## Contributing a Crate
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,59 @@
+all: check-risc-v build-risc-v check-xtensa build-xtensa clippy
+
+clippy:
+  cargo clippy --features "esp32c6,esp-hal/unstable" --release
+
+check-risc-v: build-esp32c3 build-esp32c6 build-esp32h2
+
+check-esp32c3:
+  cargo check --features "esp32c3,esp-hal/unstable" --target=riscv32imc-unknown-none-elf --release
+check-esp32c6:
+  cargo check --features "esp32c6,esp-hal/unstable" --target=riscv32imac-unknown-none-elf --release
+check-esp32h2:
+  cargo check --features "esp32h2,esp-hal/unstable" --target=riscv32imac-unknown-none-elf --release
+
+build-risc-v: build-esp32c3 build-esp32c6 build-esp32h2
+
+build-esp32c3:
+  cargo +stable build --examples --features "esp32c3,esp-hal/unstable" --target=riscv32imc-unknown-none-elf --release
+build-esp32c6:
+  cargo +stable build --examples --features "esp32c6,esp-hal/unstable" --target=riscv32imac-unknown-none-elf --release
+build-esp32h2:
+  cargo +stable build --examples --features "esp32h2,esp-hal/unstable" --target=riscv32imac-unknown-none-elf --release
+
+
+check-xtensa:  check-esp32s2 check-esp32s3 check-esp32
+
+check-esp32:
+  cargo +esp check --features "esp32,esp-hal/unstable" --target=xtensa-esp32-none-elf --release
+check-esp32s2:
+  cargo +esp check --features "esp32s2,esp-hal/unstable" --target=xtensa-esp32s2-none-elf --release
+check-esp32s3:
+  cargo +esp check --features "esp32s3,esp-hal/unstable" --target=xtensa-esp32s3-none-elf --release
+
+build-xtensa:  build-esp32s2 build-esp32s3 build-esp32
+
+build-esp32:
+  cargo +esp build --examples --features "esp32,esp-hal/unstable" --target=xtensa-esp32-none-elf --release
+build-esp32s2:
+  cargo +esp build --examples --features "esp32s2,esp-hal/unstable" --target=xtensa-esp32s2-none-elf --release
+build-esp32s3:
+  cargo +esp build --examples --features "esp32s3,esp-hal/unstable" --target=xtensa-esp32s3-none-elf --release
+
+run-esp32c3 example:
+  cargo +stable run --example {{example}} --features "esp32c3,esp-hal/unstable" --target=riscv32imc-unknown-none-elf --release
+run-esp32c6 example:
+  cargo +stable run --example {{example}} --features "esp32c6,esp-hal/unstable" --target=riscv32imac-unknown-none-elf --release
+run-esp32h2 example:
+  cargo +stable run --example {{example}} --features "esp32h2,esp-hal/unstable" --target=riscv32imac-unknown-none-elf --release
+run-esp32 example:
+  cargo +esp run --example {{example}} --features "esp32,esp-hal/unstable" --target=xtensa-esp32-none-elf --release
+run-esp32s2 example:
+  cargo +esp run --example {{example}} --features "esp32s2,esp-hal/unstable" --target=xtensa-esp32s2-none-elf --release
+run-esp32s3 example:
+  cargo +esp run --example {{example}} --features "esp32s3,esp-hal/unstable" --target=xtensa-esp32s3-none-elf --release
+
+msrv-buzzer:
+  cargo msrv find --target riscv32imac-unknown-none-elf -- cargo check -p esp-hal-buzzer --features "esp32c6,esp-hal/unstable" --target riscv32imac-unknown-none-elf
+msrv-smartled:
+  cargo msrv find --target riscv32imac-unknown-none-elf -- cargo check -p esp-hal-smartled --features "esp32c6,esp-hal/unstable" --target riscv32imac-unknown-none-elf


### PR DESCRIPTION
These justfiles should greatly simplify running the examples on various board and checking the repository in general.
I replaced the cargo aliases with them. The only disadvantage is that the `just` command needs to be installed.