### PR TITLE
fix: update smartled rmt API usage for esp-hal 1.0.0+

### DIFF
--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -214,7 +214,7 @@ where
         O: PeripheralOutput<'ch>,
         C: TxChannelCreator<'ch, Blocking>,
     {
-        let channel = channel.configure_tx(pin, led_config()).unwrap();
+        let channel = channel.configure_tx(&led_config()).unwrap().with_pin(pin);
 
         // Assume the RMT peripheral is set up to use the APB clock
         let src_clock = Clocks::get().apb_clock.as_mhz();
@@ -259,7 +259,11 @@ where
 
         // Perform the actual RMT operation.
         let channel = self.channel.take().unwrap();
-        match channel.transmit(self.rmt_buffer)?.wait() {
+        match channel
+            .transmit(self.rmt_buffer)
+            .map_err(|(e, _)| e)?
+            .wait()
+        {
             Ok(chan) => {
                 self.channel = Some(chan);
                 Ok(())
@@ -332,7 +336,7 @@ where
         O: PeripheralOutput<'ch>,
         C: TxChannelCreator<'ch, Async>,
     {
-        let channel = channel.configure_tx(pin, led_config()).unwrap();
+        let channel = channel.configure_tx(&led_config()).unwrap().with_pin(pin);
 
         // Assume the RMT peripheral is set up to use the APB clock
         let src_clock = Clocks::get().apb_clock.as_mhz();


### PR DESCRIPTION
I needed these small fixes to get esp-hal-smartled to compile with esp-hal *after* 1.0.0 (current master).

Will update the branch once there's an upstream release.

