### PR TITLE
Update esp-hal dependency to latest stable

### DIFF
--- a/esp-hal-buzzer/Cargo.toml
+++ b/esp-hal-buzzer/Cargo.toml
@@ -17,16 +17,16 @@ document-features = "^0.2.12"
 # Unstable required for:
 # - ledc
 # - delay
-esp-hal           = { version = "~1.0", features = ["requires-unstable"] }
+esp-hal           = { version = "~1.1", features = ["requires-unstable"] }
 
 [dev-dependencies]
-esp-backtrace = { version = "0.18", features = [
+esp-backtrace = { version = "0.19", features = [
   "panic-handler",
   "println",
 ] }
-esp-bootloader-esp-idf = "0.4"
-esp-hal = { version = "~1.0", features = ["unstable"] }
-esp-println = "0.16"
+esp-bootloader-esp-idf = "0.5"
+esp-hal = { version = "~1.1", features = ["unstable"] }
+esp-println = "0.17"
 
 [features]
 ## Implement `defmt::Format` on certain types.

--- a/esp-hal-smartled/Cargo.toml
+++ b/esp-hal-smartled/Cargo.toml
@@ -14,23 +14,23 @@ targets  = ["riscv32imac-unknown-none-elf"]
 [dependencies]
 defmt             = { version = "^1.0.1", optional = true }
 document-features = "^0.2.12"
-esp-hal           = { version = "~1.0", features = ["requires-unstable"] }
+esp-hal           = { version = "~1.1", features = ["requires-unstable"] }
 rgb = "0.8.52"
 smart-leds-trait  = "^0.3.2"
 
 [dev-dependencies]
 cfg-if = "1.0"
-esp-backtrace = { version = "0.18", features = [
+esp-backtrace = { version = "0.19", features = [
     "panic-handler",
     "println",
 ] }
-esp-hal = { version = "~1.0", features = ["unstable"] }
+esp-hal = { version = "~1.1", features = ["unstable"] }
 # Use esp-rtos for embassy support instead of esp-hal-embassy
-esp-rtos = { version = "^0.2", features = ["embassy"] }
-esp-bootloader-esp-idf = "0.4"
-embassy-executor = "0.9"
+esp-rtos = { version = "^0.3", features = ["embassy"] }
+esp-bootloader-esp-idf = "0.5"
+embassy-executor = "0.10"
 embassy-time = "0.5"
-esp-println = "0.16"
+esp-println = "0.17"
 smart-leds = "0.4"
 
 [features]

--- a/esp-hal-smartled/examples/hello_rgb_async.rs
+++ b/esp-hal-smartled/examples/hello_rgb_async.rs
@@ -47,8 +47,9 @@ async fn main(_spawner: Spawner) -> ! {
     }
     #[cfg(target_arch = "xtensa")]
     {
+        let sw_int = esp_hal::interrupt::software::SoftwareInterruptControl::new(p.SW_INTERRUPT);
         let timg0 = TimerGroup::new(p.TIMG0);
-        esp_rtos::start(timg0.timer0);
+        esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
     }
 
     // Configure RMT (Remote Control Transceiver) peripheral globally

--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -206,6 +206,9 @@ impl<'ch, const BUFFER_SIZE: usize> SmartLedsAdapter<'ch, BUFFER_SIZE, Grb<u8>> 
     }
 }
 
+// smart-leds-trait still uses rgb 0.8's ComponentSlice color API.
+// Remove these allowances once https://github.com/esp-rs/esp-hal-community/pull/64 is resolved.
+#[allow(deprecated)]
 impl<'ch, const BUFFER_SIZE: usize, Color> SmartLedsAdapter<'ch, BUFFER_SIZE, Color>
 where
     Color: rgb::ComponentSlice<u8>,
@@ -234,6 +237,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<'ch, const BUFFER_SIZE: usize, Color> SmartLedsWrite
     for SmartLedsAdapter<'ch, BUFFER_SIZE, Color>
 where
@@ -330,6 +334,7 @@ impl<'ch, const BUFFER_SIZE: usize> SmartLedsAdapterAsync<'ch, BUFFER_SIZE, Grb<
     }
 }
 
+#[allow(deprecated)]
 impl<'ch, const BUFFER_SIZE: usize, Color> SmartLedsAdapterAsync<'ch, BUFFER_SIZE, Color>
 where
     Color: rgb::ComponentSlice<u8>,
@@ -387,6 +392,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<'ch, const BUFFER_SIZE: usize, Color> SmartLedsWriteAsync
     for SmartLedsAdapterAsync<'ch, BUFFER_SIZE, Color>
 where

--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -225,8 +225,10 @@ where
     {
         let channel = channel.configure_tx(&led_config()).unwrap().with_pin(pin);
 
-        // Assume the RMT peripheral is set up to use the APB clock
-        let src_clock = Clocks::get().apb_clock.as_mhz();
+        #[cfg(feature = "esp32h2")]
+        let src_clock = 32u32;
+        #[cfg(not(feature = "esp32h2"))]
+        let src_clock = 80u32;
 
         Self {
             channel: Some(channel),

--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -49,7 +49,6 @@ use core::{fmt::Debug, marker::PhantomData, slice::IterMut};
 
 use esp_hal::{
     Async, Blocking,
-    clock::Clocks,
     gpio::{Level, interconnect::PeripheralOutput},
     rmt::{Channel, Error as RmtError, PulseCode, Tx, TxChannelConfig, TxChannelCreator},
 };
@@ -66,6 +65,12 @@ const SK68XX_T0H_NS: u32 = 400; // 300ns per SK6812 datasheet, 400 per WS2812. S
 const SK68XX_T0L_NS: u32 = SK68XX_CODE_PERIOD - SK68XX_T0H_NS;
 const SK68XX_T1H_NS: u32 = 850; // 900ns per SK6812 datasheet, 850 per WS2812. > 550ns is sometimes enough. Some require T1H >= 2 * T0H. Some require > 300ns T1L.
 const SK68XX_T1L_NS: u32 = SK68XX_CODE_PERIOD - SK68XX_T1H_NS;
+
+// Hardcoded (for now) values of the RMT clock
+#[cfg(feature = "esp32h2")]
+const RMT_CLOCK_MHZ: u32 = 32u32;
+#[cfg(not(feature = "esp32h2"))]
+const RMT_CLOCK_MHZ: u32 = 80u32;
 
 /// All types of errors that can happen during the conversion and transmission
 /// of LED commands
@@ -225,15 +230,10 @@ where
     {
         let channel = channel.configure_tx(&led_config()).unwrap().with_pin(pin);
 
-        #[cfg(feature = "esp32h2")]
-        let src_clock = 32u32;
-        #[cfg(not(feature = "esp32h2"))]
-        let src_clock = 80u32;
-
         Self {
             channel: Some(channel),
             rmt_buffer,
-            pulses: led_pulses_for_clock(src_clock),
+            pulses: led_pulses_for_clock(RMT_CLOCK_MHZ),
             color: PhantomData,
         }
     }
@@ -353,13 +353,10 @@ where
     {
         let channel = channel.configure_tx(&led_config()).unwrap().with_pin(pin);
 
-        // Assume the RMT peripheral is set up to use the APB clock
-        let src_clock = Clocks::get().apb_clock.as_mhz();
-
         Self {
             channel,
             rmt_buffer,
-            pulses: led_pulses_for_clock(src_clock),
+            pulses: led_pulses_for_clock(RMT_CLOCK_MHZ),
             color: PhantomData,
         }
     }

--- a/esp-hal-smartled/src/lib.rs
+++ b/esp-hal-smartled/src/lib.rs
@@ -220,7 +220,7 @@ where
         O: PeripheralOutput<'ch>,
         C: TxChannelCreator<'ch, Blocking>,
     {
-        let channel = channel.configure_tx(pin, led_config()).unwrap();
+        let channel = channel.configure_tx(&led_config()).unwrap().with_pin(pin);
 
         // Assume the RMT peripheral is set up to use the APB clock
         let src_clock = Clocks::get().apb_clock.as_mhz();
@@ -265,11 +265,17 @@ where
 
         // Perform the actual RMT operation.
         let channel = self.channel.take().unwrap();
-        match channel.transmit(self.rmt_buffer)?.wait() {
-            Ok(chan) => {
-                self.channel = Some(chan);
-                Ok(())
-            }
+        match channel.transmit(self.rmt_buffer) {
+            Ok(chan) => match chan.wait() {
+                Ok(chan) => {
+                    self.channel = Some(chan);
+                    Ok(())
+                }
+                Err((e, chan)) => {
+                    self.channel = Some(chan);
+                    Err(LedAdapterError::TransmissionError(e))
+                }
+            },
             Err((e, chan)) => {
                 self.channel = Some(chan);
                 Err(LedAdapterError::TransmissionError(e))
@@ -338,7 +344,7 @@ where
         O: PeripheralOutput<'ch>,
         C: TxChannelCreator<'ch, Async>,
     {
-        let channel = channel.configure_tx(pin, led_config()).unwrap();
+        let channel = channel.configure_tx(&led_config()).unwrap().with_pin(pin);
 
         // Assume the RMT peripheral is set up to use the APB clock
         let src_clock = Clocks::get().apb_clock.as_mhz();

--- a/justfile
+++ b/justfile
@@ -25,11 +25,11 @@ build-esp32h2:
 check-xtensa:  check-esp32s2 check-esp32s3 check-esp32
 
 check-esp32:
-  cargo +esp check --features "esp32" --target=xtensa-esp32-none-elf --release
+  cargo +esp check --features "esp32,esp-hal/unstable" --target=xtensa-esp32-none-elf --release
 check-esp32s2:
-  cargo +esp check --features "esp32s2" --target=xtensa-esp32s2-none-elf --release
+  cargo +esp check --features "esp32s2,esp-hal/unstable" --target=xtensa-esp32s2-none-elf --release
 check-esp32s3:
-  cargo +esp check --features "esp32s3" --target=xtensa-esp32s3-none-elf --release
+  cargo +esp check --features "esp32s3,esp-hal/unstable" --target=xtensa-esp32s3-none-elf --release
 
 build-xtensa:  build-esp32s2 build-esp32s3 build-esp32
 

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 all: check-risc-v build-risc-v check-xtensa build-xtensa clippy
 
 clippy:
-  cargo clippy --features "esp32c6" --target=riscv32imac-unknown-none-elf --release
+  cargo +stable clippy --features "esp32c6,esp-hal/unstable" --target=riscv32imac-unknown-none-elf -- -D warnings
 
 check-risc-v: build-esp32c3 build-esp32c6 build-esp32h2
 


### PR DESCRIPTION
This PR updates the dependencies to the newest esp-hal versions. 
Since I needed this for one of my projects to be able to use the newest esp-hal I figured I may as well make a PR here.

I had to add a bunch of unstable usage flags, I hope this is how it was intended. 

I ran `just all` and everything still seems to build.