### PR TITLE
Fix just docs target

### DIFF
--- a/justfile
+++ b/justfile
@@ -59,4 +59,4 @@ msrv-smartled:
   cargo msrv find --target riscv32imac-unknown-none-elf -- cargo check -p esp-hal-smartled --features "esp32c6" --target riscv32imac-unknown-none-elf
 
 docs:
-  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features "esp32c6, esp-hal/unstable" --target riscv32imac-unknown-none-elf
+  RUSTDOCFLAGS="--cfg docsrs -Z unstable-options" cargo +nightly doc --target=riscv32imac-unknown-none-elf --features "esp32c6,esp-hal/unstable" --no-deps


### PR DESCRIPTION
The Just "docs" target was failing with the following error:

    error[E0557]: feature has been removed
      --> ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/typenum-1.18.0/src/lib.rs:51:29
      |
    51 | #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
      |                             ^^^^^^^^^^^^ feature has been removed
      |
      = note: removed in 1.92.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
      = note: merged into `doc_cfg`

    error: Compilation failed, aborting rustdoc

    For more information about this error, try `rustc --explain E0557`.
    error: could not document `typenum`
    warning: build failed, waiting for other jobs to finish...

    Copy the GitHub command over to fix.

However, the GitHub "docs" task was working just fine. This CL just copies that command over into `justfile`.